### PR TITLE
Pass link assignments

### DIFF
--- a/lib/mazurka/resource.ex
+++ b/lib/mazurka/resource.ex
@@ -59,7 +59,8 @@ defmodule Mazurka.Resource do
           nil ->
             raise Mazurka.UnacceptableContentTypeException, [
               content_type: content_types,
-              acceptable: __mazurka_acceptable_content_types__()
+              acceptable: __mazurka_acceptable_content_types__(),
+              conn: unquote(Utils.conn)
             ]
           content_type ->
             {response, conn} = action(content_type, unquote_splicing(Utils.arguments))
@@ -85,7 +86,8 @@ defmodule Mazurka.Resource do
           nil ->
             raise Mazurka.UnacceptableContentTypeException, [
               content_type: content_types,
-              acceptable: __mazurka_acceptable_content_types__()
+              acceptable: __mazurka_acceptable_content_types__(),
+              conn: unquote(Utils.conn)
             ]
           content_type ->
             response = affordance(content_type, unquote_splicing(Utils.arguments))

--- a/lib/mazurka/resource.ex
+++ b/lib/mazurka/resource.ex
@@ -22,7 +22,6 @@ defmodule Mazurka.Resource do
       quote do
         @before_compile unquote(__MODULE__)
 
-        use Mazurka.Resource.Condition
         use Mazurka.Resource.Event
         use Mazurka.Resource.Input
         use Mazurka.Resource.Let
@@ -30,8 +29,9 @@ defmodule Mazurka.Resource do
         use Mazurka.Resource.Mediatype
         use Mazurka.Resource.Option
         use Mazurka.Resource.Param
-        use Mazurka.Resource.Validation
         use Mazurka.Resource.Utils.Scope
+        use Mazurka.Resource.Validation
+        use Mazurka.Resource.Condition
       end
     end
   end

--- a/lib/mazurka/resource/action.ex
+++ b/lib/mazurka/resource/action.ex
@@ -59,19 +59,13 @@ defmodule Mazurka.Resource.Action do
           mediatype ->
             case __mazurka_check_params__(unquote(Utils.params)) do
               {[], []} ->
-                scope = __mazurka_scope__(mediatype, unquote_splicing(Utils.arguments))
-                case __mazurka_conditions__(unquote_splicing(Utils.arguments), scope) do
-                  {:error, %{:__struct__ => _} = exception} ->
-                    raise exception
-                  {:error, message} ->
-                    raise Mazurka.ConditionException, message: message, conn: unquote(Utils.conn)
-                  :ok ->
-                    case __mazurka_validations__(unquote_splicing(Utils.arguments), scope) do
-                      {:error, message} ->
-                        raise Mazurka.ValidationException, message: message, conn: unquote(Utils.conn)
-                      :ok ->
-                        __mazurka_match_action__(mediatype, unquote_splicing(Utils.arguments), scope)
-                    end
+                case __mazurka_scope_check__(:action, mediatype, unquote_splicing(Utils.arguments)) do
+                  {:no_error, scope} ->
+                    __mazurka_match_action__(mediatype, unquote_splicing(Utils.arguments), scope)
+                  {{:validation, error_message}, _} ->
+                    raise Mazurka.ValidationException, message: error_message, conn: unquote(Utils.conn)
+                  {{:condition, error_message}, _} ->
+                    raise Mazurka.ConditionException, message: error_message, conn: unquote(Utils.conn)
                 end
               {missing, nil_params} ->
                 raise Mazurka.MissingParametersException, params: missing ++ nil_params, conn: unquote(Utils.conn)

--- a/lib/mazurka/resource/affordance.ex
+++ b/lib/mazurka/resource/affordance.ex
@@ -65,7 +65,7 @@ defmodule Mazurka.Resource.Affordance do
             case __mazurka_scope_check__(:affordance, mediatype, unquote_splicing(Utils.arguments)) do
               {:no_error, scope} ->
                 __mazurka_match_affordance__(mediatype, unquote_splicing(Utils.arguments), scope)
-              wtf ->
+              _ ->
                %Mazurka.Affordance.Undefined{resource: __MODULE__,
                                            mediatype: mediatype,
                                            params: unquote(Utils.params),

--- a/lib/mazurka/resource/affordance.ex
+++ b/lib/mazurka/resource/affordance.ex
@@ -73,7 +73,7 @@ defmodule Mazurka.Resource.Affordance do
               :ok ->
                 __mazurka_match_affordance__(mediatype, unquote_splicing(Utils.arguments), scope)
             end
-          {missing, _} when length(missing) > 0 ->
+          {[_ | _] = missing, _} ->
             raise Mazurka.MissingParametersException, params: missing, conn: unquote(Utils.conn())
           _ ->
             %Mazurka.Affordance.Undefined{resource: __MODULE__,

--- a/lib/mazurka/resource/affordance.ex
+++ b/lib/mazurka/resource/affordance.ex
@@ -62,16 +62,16 @@ defmodule Mazurka.Resource.Affordance do
       def affordance(mediatype, unquote_splicing(Utils.arguments)) when is_atom(mediatype) do
         case __mazurka_check_params__(unquote(Utils.params)) do
           {[], []} ->
-            scope = __mazurka_scope__(mediatype, unquote_splicing(Utils.arguments))
-            case __mazurka_conditions__(unquote_splicing(Utils.arguments), scope) do
-              {:error, _} ->
-                %Mazurka.Affordance.Undefined{resource: __MODULE__,
-                                              mediatype: mediatype,
-                                              params: unquote(Utils.params),
-                                              input: unquote(Utils.input),
-                                              opts: unquote(Utils.opts)}
-              :ok ->
+            case __mazurka_scope_check__(:affordance, mediatype, unquote_splicing(Utils.arguments)) do
+              {:no_error, scope} ->
                 __mazurka_match_affordance__(mediatype, unquote_splicing(Utils.arguments), scope)
+              wtf ->
+               %Mazurka.Affordance.Undefined{resource: __MODULE__,
+                                           mediatype: mediatype,
+                                           params: unquote(Utils.params),
+                                           input: unquote(Utils.input),
+                                           opts: unquote(Utils.opts)}
+
             end
           {[_ | _] = missing, _} ->
             raise Mazurka.MissingParametersException, params: missing, conn: unquote(Utils.conn())

--- a/lib/mazurka/resource/condition.ex
+++ b/lib/mazurka/resource/condition.ex
@@ -1,4 +1,9 @@
 defmodule Mazurka.Resource.Condition do
   @moduledoc false
+
   use Mazurka.Resource.Utils.Check
+
+  defmacro condition(block, message \\ nil) do
+    Scope.check(:condition, block, if message do message else block end)
+  end
 end

--- a/lib/mazurka/resource/condition.ex
+++ b/lib/mazurka/resource/condition.ex
@@ -3,7 +3,13 @@ defmodule Mazurka.Resource.Condition do
 
   use Mazurka.Resource.Utils.Check
 
-  defmacro condition(block, message \\ nil) do
+  defmacro condition(block, message \\ nil)
+
+  defmacro condition([do: block], message) do
+    Scope.check(:condition, block, if message do message else block |> Macro.to_string() end)
+  end
+
+  defmacro condition(block, message) do
     Scope.check(:condition, block, if message do message else block |> Macro.to_string() end)
   end
 end

--- a/lib/mazurka/resource/condition.ex
+++ b/lib/mazurka/resource/condition.ex
@@ -4,6 +4,6 @@ defmodule Mazurka.Resource.Condition do
   use Mazurka.Resource.Utils.Check
 
   defmacro condition(block, message \\ nil) do
-    Scope.check(:condition, block, if message do message else block end)
+    Scope.check(:condition, block, if message do message else block |> Macro.to_string() end)
   end
 end

--- a/lib/mazurka/resource/event.ex
+++ b/lib/mazurka/resource/event.ex
@@ -30,6 +30,7 @@ defmodule Mazurka.Resource.Event do
     quote do
       defp __mazurka_event__(var!(action), unquote_splicing(Utils.arguments), unquote(Utils.scope), unquote(Utils.mediatype)) do
         var!(conn) = unquote(Utils.conn)
+        _ = var!(conn)
         Mazurka.Resource.Utils.Scope.dump()
         unquote_splicing(events)
         {var!(action), var!(conn)}

--- a/lib/mazurka/resource/let.ex
+++ b/lib/mazurka/resource/let.ex
@@ -16,7 +16,7 @@ defmodule Mazurka.Resource.Let do
   """
 
   defmacro let({:=, _, [{name, _, _}, block]}) when is_atom(name) do
-    Scope.compile(name, block)
+    Scope.compile_assignment(name, block)
   end
 
   @doc """
@@ -29,6 +29,6 @@ defmodule Mazurka.Resource.Let do
   """
 
   defmacro let({name, _, _}, [do: block]) when is_atom(name) do
-    Scope.compile(name, block)
+    Scope.compile_assignment(name, block)
   end
 end

--- a/lib/mazurka/resource/link.ex
+++ b/lib/mazurka/resource/link.ex
@@ -108,6 +108,7 @@ defmodule Mazurka.Resource.Link do
         unquote(Utils.router),
         unquote(opts)
       )
+      |> Map.get(:path)
 
       var!(conn) = Mazurka.Conn.invalidate(conn, target)
 

--- a/lib/mazurka/resource/link.ex
+++ b/lib/mazurka/resource/link.ex
@@ -108,7 +108,6 @@ defmodule Mazurka.Resource.Link do
         unquote(Utils.router),
         unquote(opts)
       )
-      |> Map.get(:path)
 
       var!(conn) = Mazurka.Conn.invalidate(conn, target)
 

--- a/lib/mazurka/resource/link.ex
+++ b/lib/mazurka/resource/link.ex
@@ -23,6 +23,7 @@ defmodule Mazurka.Resource.Link do
     opts = format_opts(opts)
     Module.put_attribute(__CALLER__.module, :mazurka_links, resource)
 
+    mod = __CALLER__.module
     quote do
       conn = var!(conn)
       router = unquote(Utils.router)
@@ -38,7 +39,8 @@ defmodule Mazurka.Resource.Link do
 
       module = Mazurka.Router.resolve_resource(router, resource, source, conn)
 
-      opts = unquote(opts)
+      opts = Mazurka.Resource.Utils.Scope.dump_as_ob(unquote(mod)) |> Map.merge(unquote(opts))
+
       warn = Map.get(opts, :warn)
 
       case module do

--- a/lib/mazurka/resource/utils/check.ex
+++ b/lib/mazurka/resource/utils/check.ex
@@ -5,10 +5,11 @@ defmodule Mazurka.Resource.Utils.Check do
     module = __CALLER__.module
     name = Module.split(module) |> List.last()
     mazurka_check = :"__mazurka_#{String.downcase(name)}s__"
-    macro = :"#{String.downcase(name)}"
+    macro = :"#{String.downcase(name)}_old"
 
     quote bind_quoted: binding(), location: :keep do
       alias Mazurka.Resource.Utils
+      alias Utils.Scope
 
       defmacro __using__(_) do
         check = unquote(mazurka_check)

--- a/lib/mazurka/resource/utils/check.ex
+++ b/lib/mazurka/resource/utils/check.ex
@@ -4,69 +4,14 @@ defmodule Mazurka.Resource.Utils.Check do
   defmacro __using__(_) do
     module = __CALLER__.module
     name = Module.split(module) |> List.last()
-    mazurka_check = :"__mazurka_#{String.downcase(name)}s__"
-    macro = :"#{String.downcase(name)}_old"
 
     quote bind_quoted: binding(), location: :keep do
       alias Mazurka.Resource.Utils
       alias Utils.Scope
 
       defmacro __using__(_) do
-        check = unquote(mazurka_check)
         quote do
           import unquote(__MODULE__)
-
-          Module.register_attribute(__MODULE__, unquote(check), accumulate: true)
-          @before_compile unquote(__MODULE__)
-        end
-      end
-
-      defmacro unquote(macro)(block, message \\ nil) do
-        to_quoted(block, message)
-      end
-
-      defp to_quoted([do: block], message) do
-        to_quoted(block, message)
-      end
-      defp to_quoted(block, nil) do
-        message = message(block)
-        to_quoted(block, message)
-      end
-      defp to_quoted(block, message) do
-        check = unquote(mazurka_check)
-        quote location: :keep do
-          Module.put_attribute(__MODULE__, unquote(check), {unquote(Macro.escape(block)), unquote(message)})
-        end
-      end
-
-      defp message(block) do
-        code = Macro.to_string(block)
-        "#{unquote(name)} failure of #{inspect(code)}"
-      end
-
-      defmacro __before_compile__(env) do
-        check = unquote(mazurka_check)
-        checks = Module.get_attribute(env.module, check)
-          |> Enum.reduce(:ok, fn({block, message}, parent) ->
-            quote do
-              if unquote(block) do
-                unquote(parent)
-              else
-                {:error, unquote(message)}
-              end
-            end
-          end)
-        scope = case checks do
-          :ok ->
-            []
-          _ ->
-            [quote(do: Mazurka.Resource.Utils.Scope.dump())]
-        end
-        quote do
-          defp unquote(check)(unquote_splicing(Utils.arguments), unquote(Utils.scope)) do
-            unquote_splicing(scope)
-            unquote(checks)
-          end
         end
       end
     end

--- a/lib/mazurka/resource/utils/global.ex
+++ b/lib/mazurka/resource/utils/global.ex
@@ -12,6 +12,13 @@ defmodule Mazurka.Resource.Utils.Global do
         Mazurka.Resource.Utils.unquote(var_name)()
       end
 
+      defmacro has(name) when is_atom(name) do
+        value = Mazurka.Resource.Utils.unquote(var_name)()
+        quote do
+          unquote(value) |> Map.has_key?(unquote(name))
+        end
+      end
+
       case type do
         :binary ->
           defmacro get(name) when is_atom(name) do

--- a/lib/mazurka/resource/utils/scope.ex
+++ b/lib/mazurka/resource/utils/scope.ex
@@ -130,11 +130,23 @@ defmodule Mazurka.Resource.Utils.Scope do
     end) |> Enum.map(fn {:assignment, x} -> x end)
   end
 
+  defmacro dump_as_ob(mod) do
+    scope = Module.get_attribute(mod, :mazurka_scope) |> assignments
+
+    kvs = scope |> Enum.map(fn {n, _v} -> n end) |> Enum.uniq |> Enum.map(fn k ->
+      {k, Macro.var(k, nil)}
+    end)
+
+    # create a map of %{var_name as atom -> var name}
+    {:%{}, [], kvs}
+  end
+
   defmacro dump() do
     scope = Module.get_attribute(__CALLER__.module, :mazurka_scope) |> assignments
 
     vars = Enum.map(scope, fn({n, _}) -> Macro.var(n, nil) end)
     assigns = Enum.map(scope, fn({n, _}) -> quote(do: _ = unquote(Macro.var(n, nil))) end)
+
     quote do
       var!(conn) = unquote(Utils.conn)
       _ = var!(conn)

--- a/lib/mazurka/resource/utils/scope.ex
+++ b/lib/mazurka/resource/utils/scope.ex
@@ -71,6 +71,8 @@ defmodule Mazurka.Resource.Utils.Scope do
     vars = Enum.map(scope, fn({n, _}) -> Macro.var(n, nil) end)
     assigns = Enum.map(scope, fn({n, _}) -> quote(do: _ = unquote(Macro.var(n, nil))) end)
     quote do
+      var!(conn) = unquote(Utils.conn)
+      _ = var!(conn)
       {unquote_splicing(vars)} = unquote(Utils.scope)
       unquote_splicing(assigns)
     end

--- a/lib/mazurka/resource/utils/scope.ex
+++ b/lib/mazurka/resource/utils/scope.ex
@@ -69,11 +69,17 @@ defmodule Mazurka.Resource.Utils.Scope do
         end |> elem(2)
 
       {:check, {check_type, condition, error_code}} ->
+
+        # This avoids a "this check/guard will always yield the same result"
+        # warning during compilation when making use of validations
+        tcheck = if check_type == :validation do
+            quote do: resource_type == :affordance
+          else
+            quote do: false
+          end
         quote do
           mazurka_error__ = 
-            if (mazurka_error__ != :no_error ||
-              (unquote(check_type) == :validation && resource_type == :affordance)
-              ) do
+            if (mazurka_error__ != :no_error || unquote(tcheck)) do
               mazurka_error__
             else
               if (unquote(condition)) do

--- a/lib/mazurka/resource/validation.ex
+++ b/lib/mazurka/resource/validation.ex
@@ -4,6 +4,6 @@ defmodule Mazurka.Resource.Validation do
   use Mazurka.Resource.Utils.Check
 
   defmacro validation(block, message \\ nil) do
-    Scope.check(:validation, block, if message do message else block end)
+    Scope.check(:validation, block, if message do message else block |> Macro.to_string() end)
   end
 end

--- a/lib/mazurka/resource/validation.ex
+++ b/lib/mazurka/resource/validation.ex
@@ -1,4 +1,9 @@
 defmodule Mazurka.Resource.Validation do
   @moduledoc false
+
   use Mazurka.Resource.Utils.Check
+
+  defmacro validation(block, message \\ nil) do
+    Scope.check(:validation, block, if message do message else block end)
+  end
 end

--- a/lib/mazurka/resource/validation.ex
+++ b/lib/mazurka/resource/validation.ex
@@ -3,7 +3,13 @@ defmodule Mazurka.Resource.Validation do
 
   use Mazurka.Resource.Utils.Check
 
-  defmacro validation(block, message \\ nil) do
+  defmacro validation(block, message \\ nil)
+
+  defmacro validation([do: block], message) do
+    Scope.check(:validation, block, if message do message else block |> Macro.to_string() end)
+  end
+
+  defmacro validation(block, message) do
     Scope.check(:validation, block, if message do message else block |> Macro.to_string() end)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Mazurka.Mixfile do
 
   def project do
     [app: :mazurka,
-     version: "1.0.7",
+     version: "1.0.8",
      elixir: "~> 1.0",
      description: "hypermedia api toolkit",
      test_coverage: [tool: ExCoveralls],

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Mazurka.Mixfile do
      description: "hypermedia api toolkit",
      test_coverage: [tool: ExCoveralls],
      preferred_cli_env: [
-       "coveralls": :test,
+       coveralls: :test,
        "coveralls.circle": :test,
        "coveralls.detail": :test,
        "coveralls.html": :test


### PR DESCRIPTION
For any assignment (inputs, params, options, lets), pass those into link_to as `Options` in case they may be useful, rather than throwing them away or requiring manual passing of every binding.  That route can make use of them if it wants to.